### PR TITLE
Revise example in README.md and remove test output

### DIFF
--- a/qfusion-opt/README.md
+++ b/qfusion-opt/README.md
@@ -91,8 +91,8 @@ $ ./cpu/Quokka -i sub_cpu.ini -c [circuit_file]
 ### Example
 
 ```bash
-$ python3 env_init.py
-$ python3 performance_model.py 32 18
+$ python3 python/env_init.py
+$ python3 python/performance_model.py 32 18
 $ ./fusion ./circuit/sc24.txt ./fusionCircuit/sc24.txt 3 24 3
 $ finder/finder ./fusionCircuit/sc24.txt out.txt 18
 $ cpu/Quokka -i sub_cpu.ini -c out.txt

--- a/qfusion-opt/python/test_fusion_no_finder.py
+++ b/qfusion-opt/python/test_fusion_no_finder.py
@@ -111,7 +111,6 @@ if __name__ == '__main__':
         time = 0
         for i in range(times):
             output = subprocess.run(["./cpu/Quokka", "-i", "sub_cpu.ini", "-c", "./subCircuit/" + file_name], capture_output=True, text=True)
-            print(i, output, "\n")
             time = time + float(output.stdout.split()[-1].split("s")[0])
         print("origin: ", time / times)
         # static Qiskit


### PR DESCRIPTION
Correct the execution path in example. Remove the test output which I used to examine the correctness of `python/test_fusion_no_finder.py`